### PR TITLE
fix: handle vim.NIL priority field in issue rendering

### DIFF
--- a/lua/jira/edit/init.lua
+++ b/lua/jira/edit/init.lua
@@ -13,7 +13,7 @@ local function render_issue_as_md(issue)
   table.insert(lines, "")
 
   -- Metadata
-  local priority = fields.priority and fields.priority.name or "None"
+  local priority = fields.priority and fields.priority ~= vim.NIL and fields.priority.name or "None"
   table.insert(lines, ("**Priority**: %s"):format(priority))
 
   local assignee = "Unassigned"

--- a/lua/jira/issue/render.lua
+++ b/lua/jira/issue/render.lua
@@ -78,7 +78,10 @@ function M.render_content()
       assignee_name = fields.assignee.displayName
     end
     table.insert(lines, "**Assignee**: " .. assignee_name)
-    table.insert(lines, "**Priority**: " .. (fields.priority and fields.priority.name or "None"))
+    table.insert(
+      lines,
+      "**Priority**: " .. (fields.priority and fields.priority ~= vim.NIL and fields.priority.name or "None")
+    )
 
     -- Display labels if they exist
     if fields.labels and type(fields.labels) == "table" and #fields.labels > 0 then


### PR DESCRIPTION
I was getting the errors of the like:

```
Lua callback: .../.local/share/nvim/lazy/jira.nvim/lua/jira/edit/init.lua:16: attempt to index field 'priority' (a userdata value)
...
Error executing vim.schedule lua callback: ...ocal/share/nvim/lazy/jira.nvim/lua/jira/issue/render.lua:81: attempt to index field 'priority' (a userdata value)
```
same pattern as in the current fix was used throughout the `lua/jira/edit/init.lua`  and for the `fields.assignee` in `lua/jira.issue/render.lua`